### PR TITLE
New Event - Chicago PHP User Group Lightning Talks

### DIFF
--- a/content/eventslist/2019-08-12-chicagophpusergrouplightningtalks.md
+++ b/content/eventslist/2019-08-12-chicagophpusergrouplightningtalks.md
@@ -1,0 +1,25 @@
+---
+title: "Chicago PHP User Group Lightning Talks"
+date: "2019-08-04T17:05:41.771Z"
+startDate: "2019-08-12 00:00"
+startTime: "6:30pm"
+endDate: "2019-08-13T00:00:00.000Z"
+endTime: "8:00pm"
+locationName: "Earlybird"
+locationStreet: "218 S Wabash Ave #280"
+locationCity: "Chicago"
+locationState: "IL"
+cost: "FREE"
+eventUrl: "https://www.meetup.com/Chicago-PHP-User-Group/events/262976448/"
+
+---
+
+Multiple speakers presenting lightning talks (10 minutes or less) on various topics with about 5 minutes after each talk for questions. 
+
+Speakers: 
+1. Jay Rodge - Introduction to Machine Learning in PHP
+2. Mikael Mayer - (a subset of) PHP-powered webpages made Live Editable with the Tharzen Editor
+3. Bald Mike - Events
+4. Mario Campos - PHP and OpenBSD
+5. Roy Verrips - Livewire 
+


### PR DESCRIPTION
New event listing request - 2019-08-12-chicagophpusergrouplightningtalks.md - via Meetup Group: Chicago PHP User Group