### PR TITLE
New Event - Tech Debates Chicago: Building an engineering team from start-up to scale. 

### DIFF
--- a/content/eventslist/2019-12-12-techdebateschicagobuildinganengineeringteamfromstar.md
+++ b/content/eventslist/2019-12-12-techdebateschicagobuildinganengineeringteamfromstar.md
@@ -1,0 +1,18 @@
+---
+title: "Tech Debates Chicago: Building an engineering team from start-up to scale. "
+date: "2019-11-18T19:29:21.595Z"
+startDate: "2019-12-12 00:00"
+startTime: "5:15pm"
+endDate: "2019-12-12 00:00"
+endTime: "6:45pm"
+locationName: "TechNexus"
+locationStreet: "20 N Upper Wacker Dr #1200"
+locationCity: "Chicago"
+locationState: "IL"
+cost: "FREE"
+eventUrl: "https://www.meetup.com/meetup-group-yycuKtwU/events/266500395/"
+
+---
+
+Tech Debates will be in Chicago to bring you a lineup of seasoned CTOs, who will discuss key issues in scaling an engineering team, and their solutions.
+


### PR DESCRIPTION
New event listing request - 2019-12-12-techdebateschicagobuildinganengineeringteamfromstar.md - via Meetup Group: Chicago Tech Debates