### PR TITLE
New Event - Self Serve Testing: 2 Years of Docker Swarm in AWS

### DIFF
--- a/content/eventslist/2020-02-12-selfservetesting2yearsofdockerswarminaws.md
+++ b/content/eventslist/2020-02-12-selfservetesting2yearsofdockerswarminaws.md
@@ -1,0 +1,18 @@
+---
+title: "Self Serve Testing: 2 Years of Docker Swarm in AWS"
+date: "2020-01-20T17:51:13.465Z"
+startDate: "2020-02-12 00:00"
+startTime: "6:00pm"
+endDate: "2020-02-12 00:00"
+endTime: "8:00pm"
+locationName: "ReviewTrackers"
+locationStreet: "1 N State St Suite 600"
+locationCity: "Chicago"
+locationState: "IL"
+cost: "FREE"
+eventUrl: "https://www.meetup.com/Chicago-Seleniumistas/events/268023255/"
+
+---
+
+With teams being expected to deliver new features faster than ever before, the importance of rapid on-demand testing has only become more important. Similarly, as teams grow, it becomes critical to have a scalable system through which developers can deploy production-like environments for a multitude of different services. Over the past two years ReviewTrackers has grown from using a static-environment development pipeline to a highly scalable set of tools allowing deployment of ephemeral environments for QA and CI/CD purposes. This has enabled us to maintain a rapid pace of development involving multiple deploys per day, a rapid development feedback loop, and fast onboarding for new developers.
+


### PR DESCRIPTION
New event listing request - 2020-02-12-selfservetesting2yearsofdockerswarminaws.md - via Meetup Group: Chicago Seleniumistas