### PR TITLE
New Event - Staying Engaged: Skills for the Data Scientist (Fireside Chat with Shoprunner)

### DIFF
--- a/content/eventslist/2020-02-18-stayingengagedskillsforthedatascientistfiresidecha.md
+++ b/content/eventslist/2020-02-18-stayingengagedskillsforthedatascientistfiresidecha.md
@@ -1,0 +1,18 @@
+---
+title: "Staying Engaged: Skills for the Data Scientist (Fireside Chat with Shoprunner)"
+date: "2020-01-29T17:37:57.381Z"
+startDate: "2020-02-18T17:34:50.000Z"
+startTime: "6:00pm"
+endDate: "2020-02-18T17:34:50.000Z"
+endTime: "8:00pm"
+locationName: "GA @ TechNexus"
+locationStreet: "20 N. Upper Wacker Drive, 12th Floor"
+locationCity: "Chicago"
+locationState: "IL"
+cost: "FREE"
+eventUrl: "https://generalassemb.ly/education/staying-engaged-skills-for-the-data-scientist-fireside-chat-with-shoprunner/chicago/102185"
+
+---
+
+The definition of data science is constantly in flux - as are the skills, structures, and responsibilities required to actually be a data scientist. During this fireside chat, Michelangelo D'Agostino sits down with Dataiku to explain the most valuable skills for data scientists (and their managers), as well as the organizational and leadership considerations shaping the role. From new tooling to avoiding FOMO through continuing education, we'll not only explore what is useful for the role - but also how to stay engaged, entertained, and constantly learning.
+


### PR DESCRIPTION
New event listing request - 2020-02-18-stayingengagedskillsforthedatascientistfiresidecha.md - via General Assembly Chicago